### PR TITLE
syntax highlighting for rust and other snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ This library is a form of buffer which removes this metadata header. It does thi
 ## Compiling
 
 To compile install rust from [rustup](https://rustup.rs/), check out this repository and run:
-
+```bash
     cargo install --path .
-
+```
 ## Command Line Usage
 
 This can be used like the following:
-
+```bash
     cat with_metadata_headers.csv | csv-guillotine --separator=',' --consider=20 > csv_header_and_data only.csv
-
+```
 or 
-
+```bash
     csv-guillotine -i with_metadata_headers.csv -o csv_header_and_data only.csv
-
+```
 see `csv-guillotine --help` for full usage instructions
 
 Errors will be printed to STDERR and their existence can be detected via the exit status.
@@ -47,7 +47,7 @@ NOTE: This software makes no attempt to actually validate that your CSV.
 This library exposes a `Blade` class which is constructed with a [`BufReader`](https://doc.rust-lang.org/std/io/struct.BufReader.html) as well as a character (expressed as a u8) and a line limit. The `Blade` class can be used as a [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) to get the actual data out.
 
 Example below:
-
+```rust
     use std::io::{BufRead, BufReader};
     mod lib;
 
@@ -72,3 +72,4 @@ Example below:
         }
 
     }
+```


### PR DESCRIPTION
this is nit picking, but looks way better ;)

Github flavored markdown allows you to get syntax highlighting when posting code in \``` \``` brackets.
e.g.
\```python
\# some python comment
let foo = bar()
\```
will render to 
```python
# some python comment
foo = bar()
x = abs(6.0 - 90.0)
```

the same with rust: 
\```rust
let mut foo = bar()?;
\```
will render to
```rust
// some rust comment
let mut foo = bar()?;
let s: &str = "foobar";
```

More info [here](https://help.github.com/en/articles/creating-and-highlighting-code-blocks)